### PR TITLE
Fix initial starting line log in fs

### DIFF
--- a/packages/netlify-cms-backend-fs/scripts/fs/fs-api.js
+++ b/packages/netlify-cms-backend-fs/scripts/fs/fs-api.js
@@ -6,10 +6,10 @@ const log = console.log;
 const { version, name } = require('../../package.json');
 const packageLabel = `[${name}]`
 
-log(chalk.green(`${packageLabel} (version: ${version}) \n`));
+log(chalk.green(`${packageLabel} (version: ${version})`));
 
 const projectRoot = path.join(process.cwd());
-log(chalk.green(`${packageLabel} root path is ${projectRoot} \n`));
+log(chalk.green(`${packageLabel} root path is ${projectRoot}`));
 
 const siteRoot = {
   dir: path.join(projectRoot, "example")


### PR DESCRIPTION
One last little change! I noticed that the template tag string on the first line was interfering with other console output. Added a newline just before the start, and grouped it with the second log so it feels more sturdy: 

**Before**: 

<img width="758" alt="screen shot 2019-01-26 at 10 39 08 am" src="https://user-images.githubusercontent.com/236943/51791378-e090c980-2156-11e9-99a8-628571b6e6fc.png">

**After**: 

<img width="769" alt="screen shot 2019-01-26 at 10 38 16 am" src="https://user-images.githubusercontent.com/236943/51791382-e5557d80-2156-11e9-80ea-eb3fedcf9ae3.png">
